### PR TITLE
PER-10-map-nav-zindex

### DIFF
--- a/style.css
+++ b/style.css
@@ -1867,7 +1867,7 @@ body.modal-open { overflow: hidden; }
   border-bottom: 2px solid var(--border);
   position: sticky;
   top: 0;
-  z-index: 10;
+  z-index: 1001;
 }
 
 .map-screen-title {


### PR DESCRIPTION
## Summary
- Fix map screen nav bar overlapping issue — Leaflet controls use z-index 1000, bumped `.map-screen-nav` to 1001 so it always renders on top

🤖 Generated with [Claude Code](https://claude.com/claude-code)